### PR TITLE
Add OPENAI_MODEL env support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for D.B.A.I.
+OPENAI_API_KEY=your-openai-key
+OPENAI_MODEL=gpt-4o

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv/
 
 # Arquivos de configuração e segurança
 .env
+!/.env.example
 .env.*
 
 # Cache do Python

--- a/README.md
+++ b/README.md
@@ -31,14 +31,22 @@ pip install -r requirements.txt
 ```
 
 ### 4. Configure seu arquivo `.env`
-Crie um arquivo `.env` com o seguinte conteúdo:
+Um arquivo `\.env.example` acompanha o projeto com as variáveis necessárias. Copie
+esse arquivo para `\.env` e edite com suas credenciais:
+
+```bash
+cp .env.example .env
+```
+
+O arquivo de exemplo possui o seguinte formato:
 
 ```env
-OPENAI_API_KEY=sk-sua-chave-aqui
+OPENAI_API_KEY=your-openai-key
 OPENAI_MODEL=gpt-4o
 ```
 
 > Use `gpt-4o` ou `gpt-3.5-turbo` conforme sua assinatura da OpenAI.
+Defina a variável `OPENAI_MODEL` para usar outro modelo; caso omita, o padrão é `gpt-4o`.
 
 ### 5. Rode a aplicação
 ```bash

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ load_dotenv()
 
 # Define o modelo
 model = OpenAIChat(
-    id="gpt-4o", 
+    id=os.getenv("OPENAI_MODEL", "gpt-4o"),
     api_key=os.getenv("OPENAI_API_KEY")
 )
 


### PR DESCRIPTION
## Summary
- read model ID from `OPENAI_MODEL` environment variable with default `gpt-4o`
- document the variable in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_6841f5b25e7083329813f2b733b43dbc